### PR TITLE
Allow dynamic dates based on a pattern

### DIFF
--- a/src/main/java/com/dsh105/holoapi/util/TagFormatter.java
+++ b/src/main/java/com/dsh105/holoapi/util/TagFormatter.java
@@ -5,27 +5,46 @@ import org.bukkit.entity.Player;
 
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class TagFormatter {
 
-    public static String format(Player observer, String content) {
-        if (content.contains("%time%")) {
-            Calendar c = Calendar.getInstance();
-            c.add(Calendar.HOUR_OF_DAY, HoloAPI.getInstance().getConfig(HoloAPI.ConfigType.MAIN).getInt("timezone.offset", 0));
-            content = content.replace("%time%", new SimpleDateFormat("h:mm a" + (HoloAPI.getInstance().getConfig(HoloAPI.ConfigType.MAIN).getBoolean("timezone.showZoneMarker") ? " z" : "")).format(c.getTime()));
-        }
+	public static String format(Player observer, String content) {
+		if (content.contains("%time%")) {
+			Calendar c = Calendar.getInstance();
+			c.add(Calendar.HOUR_OF_DAY, HoloAPI.getInstance().getConfig(HoloAPI.ConfigType.MAIN).getInt("timezone.offset", 0));
+			content = content.replace("%time%", new SimpleDateFormat("h:mm a" + (HoloAPI.getInstance().getConfig(HoloAPI.ConfigType.MAIN).getBoolean("timezone.showZoneMarker") ? " z" : "")).format(c.getTime()));
+		}
 
-        content = content.replace("%mctime%", TimeFormat.format12(observer.getWorld().getTime()));
-        content = content.replace("%name%", observer.getName());
-        content = content.replace("%balance%", HoloAPI.getInstance().getVaultHook().getBalance(observer));
-        content = content.replace("%rank%", HoloAPI.getInstance().getVaultHook().getRank(observer));
-        content = UnicodeFormatter.replaceAll(content);
+		content = content.replace("%mctime%", TimeFormat.format12(observer.getWorld().getTime()));
+		content = content.replace("%name%", observer.getName());
+		content = content.replace("%balance%", HoloAPI.getInstance().getVaultHook().getBalance(observer));
+		content = content.replace("%rank%", HoloAPI.getInstance().getVaultHook().getRank(observer));
+		content = matchDate(content);
+		content = UnicodeFormatter.replaceAll(content);
 
-        if (content.length() > 64 && !HoloAPI.isUsingNetty) {
-            // 1.6.x client crashes if a name tag is longer than 64 characters
-            // Unfortunate, but it must be countered for
-            content = content.substring(0, 64);
-        }
-        return content;
-    }
+		if (content.length() > 64 && !HoloAPI.isUsingNetty) {
+			// 1.6.x client crashes if a name tag is longer than 64 characters
+			// Unfortunate, but it must be countered for
+			content = content.substring(0, 64);
+		}
+		return content;
+	}
+	
+	
+	private static String matchDate(String content) {
+		Pattern datePattern = Pattern.compile("\\%date:(.+?)\\%");
+		Matcher matcher = datePattern.matcher(content);
+
+		while(matcher.find()) {
+			SimpleDateFormat format = new SimpleDateFormat(matcher.group(1));
+
+			Calendar calendar = Calendar.getInstance();
+			calendar.add(Calendar.HOUR_OF_DAY, HoloAPI.getInstance().getConfig(HoloAPI.ConfigType.MAIN).getInt("timezone.offset", 0));
+
+			content = content.replace(matcher.group(), format.format(calendar.getTime()));
+		}
+		return content;
+	}
 }

--- a/src/main/java/com/dsh105/holoapi/util/TagFormatter.java
+++ b/src/main/java/com/dsh105/holoapi/util/TagFormatter.java
@@ -10,41 +10,41 @@ import java.util.regex.Pattern;
 
 public class TagFormatter {
 
-	public static String format(Player observer, String content) {
-		if (content.contains("%time%")) {
-			Calendar c = Calendar.getInstance();
-			c.add(Calendar.HOUR_OF_DAY, HoloAPI.getInstance().getConfig(HoloAPI.ConfigType.MAIN).getInt("timezone.offset", 0));
-			content = content.replace("%time%", new SimpleDateFormat("h:mm a" + (HoloAPI.getInstance().getConfig(HoloAPI.ConfigType.MAIN).getBoolean("timezone.showZoneMarker") ? " z" : "")).format(c.getTime()));
-		}
+    public static String format(Player observer, String content) {
+        if (content.contains("%time%")) {
+            Calendar c = Calendar.getInstance();
+            c.add(Calendar.HOUR_OF_DAY, HoloAPI.getInstance().getConfig(HoloAPI.ConfigType.MAIN).getInt("timezone.offset", 0));
+            content = content.replace("%time%", new SimpleDateFormat("h:mm a" + (HoloAPI.getInstance().getConfig(HoloAPI.ConfigType.MAIN).getBoolean("timezone.showZoneMarker") ? " z" : "")).format(c.getTime()));
+        }
 
-		content = content.replace("%mctime%", TimeFormat.format12(observer.getWorld().getTime()));
-		content = content.replace("%name%", observer.getName());
-		content = content.replace("%balance%", HoloAPI.getInstance().getVaultHook().getBalance(observer));
-		content = content.replace("%rank%", HoloAPI.getInstance().getVaultHook().getRank(observer));
-		content = matchDate(content);
-		content = UnicodeFormatter.replaceAll(content);
+        content = content.replace("%mctime%", TimeFormat.format12(observer.getWorld().getTime()));
+        content = content.replace("%name%", observer.getName());
+        content = content.replace("%balance%", HoloAPI.getInstance().getVaultHook().getBalance(observer));
+        content = content.replace("%rank%", HoloAPI.getInstance().getVaultHook().getRank(observer));
+        content = matchDate(content);
+        content = UnicodeFormatter.replaceAll(content);
 
-		if (content.length() > 64 && !HoloAPI.isUsingNetty) {
-			// 1.6.x client crashes if a name tag is longer than 64 characters
-			// Unfortunate, but it must be countered for
-			content = content.substring(0, 64);
-		}
-		return content;
-	}
-	
-	
-	private static String matchDate(String content) {
-		Pattern datePattern = Pattern.compile("\\%date:(.+?)\\%");
-		Matcher matcher = datePattern.matcher(content);
+        if (content.length() > 64 && !HoloAPI.isUsingNetty) {
+            // 1.6.x client crashes if a name tag is longer than 64 characters
+            // Unfortunate, but it must be countered for
+            content = content.substring(0, 64);
+        }
+        return content;
+    }
 
-		while(matcher.find()) {
-			SimpleDateFormat format = new SimpleDateFormat(matcher.group(1));
 
-			Calendar calendar = Calendar.getInstance();
-			calendar.add(Calendar.HOUR_OF_DAY, HoloAPI.getInstance().getConfig(HoloAPI.ConfigType.MAIN).getInt("timezone.offset", 0));
+    private static String matchDate(String content) {
+        Pattern datePattern = Pattern.compile("\\%date:(.+?)\\%");
+        Matcher matcher = datePattern.matcher(content);
 
-			content = content.replace(matcher.group(), format.format(calendar.getTime()));
-		}
-		return content;
-	}
+        while(matcher.find()) {
+            SimpleDateFormat format = new SimpleDateFormat(matcher.group(1));
+
+            Calendar calendar = Calendar.getInstance();
+            calendar.add(Calendar.HOUR_OF_DAY, HoloAPI.getInstance().getConfig(HoloAPI.ConfigType.MAIN).getInt("timezone.offset", 0));
+
+            content = content.replace(matcher.group(), format.format(calendar.getTime()));
+        }
+        return content;
+    }
 }


### PR DESCRIPTION
The Issue

The current way to display time on a hologram is very limited.

Justification for this PR:

Allow more more customization of holograms, providing a more "all in one" package. 

PR Breakdown

Adds a new tag that can be specified on hologram creation.
The tag is: %date:'date format'%
The 'date format' part will be phrased by java's SimpleDateFormat then the whole tag is replaced by the output.
The syntax can be found here: http://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html

 eg: The time is: %date:"h:mm a"% will be The time is: 12:08 PM

Relevant PR(s) and Issue(s)

Currently it's pointless to display any unit below minutes.
Since holograms are only refreshed every 1 minute.
