### PR TITLE
Fix InjectionManager

### DIFF
--- a/src/main/java/com/dsh105/holoapi/protocol/InjectionManager.java
+++ b/src/main/java/com/dsh105/holoapi/protocol/InjectionManager.java
@@ -161,7 +161,7 @@ public class InjectionManager {
                 int id = (Integer) packet.read("a");
                 // The action is whether or not it was a right or left click.
                 Object rawAction = packet.read("action");
-                Action action = rawAction instanceof Integer ? Action.getFromId((Integer) rawAction) : readAction(rawAction);
+                Action action = rawAction instanceof Integer ? Action.getFromId(Integer.valueOf(String.valueOf(rawAction))) : readAction(rawAction);
 
                 for (Hologram hologram : HoloAPI.getManager().getAllHolograms().keySet()) {
                     for (int entityId : hologram.getAllEntityIds()) {


### PR DESCRIPTION
# java.lang.ClassCastException: com.dsh105.holoapi.protocol.Action cannot be cast to java.lang.Integer

[21:08:08 WARN]: [HoloAPI] Task #1450 for HoloAPI v1.2.2-SNAPSHOT generated an exception
java.lang.ClassCastException: com.dsh105.holoapi.protocol.Action cannot be cast to java.lang.Integer
at com.dsh105.holoapi.protocol.InjectionManager$2.run(InjectionManager.java:164) ~[?:?]
at org.bukkit.craftbukkit.v1_7_R3.scheduler.CraftTask.run(CraftTask.java:58) ~[spigot.jar:git-Spigot-1443]
at org.bukkit.craftbukkit.v1_7_R3.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:345) [spigot.jar:git-Spigot-1443]
at net.minecraft.server.v1_7_R3.MinecraftServer.v(MinecraftServer.java:628) [spigot.jar:git-Spigot-1443]
at net.minecraft.server.v1_7_R3.DedicatedServer.v(DedicatedServer.java:283) [spigot.jar:git-Spigot-1443]
at net.minecraft.server.v1_7_R3.MinecraftServer.u(MinecraftServer.java:576) [spigot.jar:git-Spigot-1443]
at net.minecraft.server.v1_7_R3.MinecraftServer.run(MinecraftServer.java:482) [spigot.jar:git-Spigot-1443]
at net.minecraft.server.v1_7_R3.ThreadServerApplication.run(SourceFile:628) [spigot.jar:git-Spigot-1443]
