### PR TITLE
Quicker stopTracking method in SimpleHoloManager.

### DIFF
--- a/src/main/java/com/dsh105/holoapi/api/SimpleHoloManager.java
+++ b/src/main/java/com/dsh105/holoapi/api/SimpleHoloManager.java
@@ -147,8 +147,10 @@ public class SimpleHoloManager implements HoloManager {
 
     @Override
     public void stopTracking(Hologram hologram) {
+        boolean removed = this.holograms.remove(hologram) != null;
+        if(!removed) return; // No need to go on if we weren't already tracking it...
+        
         hologram.clearAllPlayerViews();
-        this.holograms.remove(hologram);
         if (hologram instanceof AnimatedHologram && ((AnimatedHologram) hologram).isAnimating()) {
             ((AnimatedHologram) hologram).cancelAnimation();
         }


### PR DESCRIPTION
No need to continue executing code in SimpleHoloManager.stopTracking(Hologram) if the hologram wasn't removed to begin with.
